### PR TITLE
CORS

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 # Third party imports
 from flask import Flask
 from flask.json import JSONEncoder
+from flask_cors import CORS
 from sqlalchemy.ext.declarative import DeclarativeMeta
 
 # Local application imports
@@ -19,6 +20,9 @@ class Application:
         app = Flask(__name__)
         app.app_context().push()
         app.config.from_object(config)
+
+        # Allow cross-origin requests
+        CORS(app)
 
         # Bind SQLAlchemy database engine to flask app
         db.init_app(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Flask==1.1.1
 bandit==1.6.2
 Flask-SQLAlchemy==2.4.1
 mysql-connector-python==8.0.19
+flask-cors==3.0.8


### PR DESCRIPTION
We need to allow cross-origin resource sharing (CORS) on our API to allow the frontend to make requests to it.
This is a bit barebones (read: insecure), but works.